### PR TITLE
Add JSON Decoder for HTML events

### DIFF
--- a/example/Decoder.elm
+++ b/example/Decoder.elm
@@ -1,0 +1,45 @@
+module Main exposing (..)
+
+import Html exposing (..)
+import Html.Events exposing (on)
+import Html.App as Html
+import Keyboard.Extra as Keyboard
+import Json.Decode as Json
+
+
+main : Program Never
+main =
+    Html.beginnerProgram
+        { model = init
+        , update = update
+        , view = view
+        }
+
+
+type alias Model =
+    Maybe Keyboard.Key
+
+
+init : Model
+init =
+    Nothing
+
+
+type Msg
+    = KeyPress Keyboard.Key
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        KeyPress char ->
+            Just char
+
+
+view : Model -> Html Msg
+view model =
+    div []
+        [ p [] [ text "Enter text below:" ]
+        , textarea [ on "keydown" <| Json.map KeyPress Keyboard.targetKey ] []
+        , p [] [ text <| toString model ]
+        ]

--- a/src/Keyboard/Extra.elm
+++ b/src/Keyboard/Extra.elm
@@ -13,6 +13,7 @@ module Keyboard.Extra
         , Key(..)
         , Model
         , Msg
+        , targetKey
         )
 
 {-| Convenience helpers for working with keyboard inputs.
@@ -26,6 +27,9 @@ module Keyboard.Extra
 # Wiring
 @docs Model, Msg, subscriptions, init, update
 
+# Decoder
+@docs targetKey
+
 # Keyboard keys
 @docs Key
 -}
@@ -33,6 +37,7 @@ module Keyboard.Extra
 import Keyboard exposing (KeyCode)
 import Dict exposing (Dict)
 import Set exposing (Set)
+import Json.Decode as Json exposing ((:=))
 import Keyboard.Arrows as Arrows exposing (Arrows)
 
 
@@ -209,6 +214,19 @@ toCode key =
         |> List.map fst
         |> List.head
         |> Maybe.withDefault 0
+
+
+{-| A `Json.Decoder` for grabbing `event.keyCode` and turning it into a `Key`
+
+    import Json.Decode as Json
+
+    onKey : (Key -> msg) -> Attribute msg
+    onKey tagger =
+      on "keydown" (Json.map tagger targetKey)
+-}
+targetKey : Json.Decoder Key
+targetKey =
+    Json.map fromCode ("keyCode" := Json.int)
 
 
 {-| These are all the keys that have names in `Keyboard.Extra`.


### PR DESCRIPTION
Hi Ossi,

It is useful to have these nicely defined key types available for Html
events as well as subscriptions. This commit adds a simple Json
decoder function that takes a keyUp/keyDown event and returns a
Keyboard.Key.

I have also added an example file that demonstrates its usage.

Hope that it's all ok.

ps. Thanks for this awesome package! 
