### PR TITLE
Remove unnecessary Cmd boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,14 @@ Initialize the component
 init : ( Model, Cmd Msg )
 init =
     let
-        ( keyboardModel, keyboardCmd ) =
+        keyboardModel =
             Keyboard.Extra.init
     in
         ( { keyboardModel = keyboardModel
           , otherThing = 0
           -- ...
           }
-        , Cmd.batch
-            [ Cmd.map KeyboardExtraMsg keyboardCmd
-            -- ..
-            ]
+        , Cmd.none
         )
 ```
 
@@ -69,11 +66,11 @@ update msg model =
     case msg of
         KeyboardExtraMsg keyMsg ->
             let
-                ( keyboardModel, keyboardCmd ) =
+                keyboardModel=
                     Keyboard.Extra.update keyMsg model.keyboardModel
             in
                 ( { model | keyboardModel = keyboardModel }
-                , Cmd.map KeyboardMsg keyboardCmd
+                , Cmd.none
                 )
         -- ...
 ```

--- a/example/Main.elm
+++ b/example/Main.elm
@@ -33,11 +33,11 @@ init =
         arr =
             { x = 0, y = 0 }
 
-        ( keyboardModel, keyboardCmd ) =
+        keyboardModel =
             Keyboard.init
     in
         ( Model keyboardModel False arr arr []
-        , Cmd.map KeyboardMsg keyboardCmd
+        , Cmd.none
         )
 
 
@@ -46,7 +46,7 @@ update msg model =
     case msg of
         KeyboardMsg keyMsg ->
             let
-                ( keyboardModel, keyboardCmd ) =
+                keyboardModel =
                     Keyboard.update keyMsg model.keyboardModel
             in
                 ( { model
@@ -56,7 +56,7 @@ update msg model =
                     , wasd = Keyboard.wasd keyboardModel
                     , keyList = Keyboard.pressedDown keyboardModel
                   }
-                , Cmd.map KeyboardMsg keyboardCmd
+                , Cmd.none
                 )
 
 

--- a/example/VisualArrows.elm
+++ b/example/VisualArrows.elm
@@ -28,11 +28,11 @@ type alias Model =
 init : ( Model, Cmd Msg )
 init =
     let
-        ( keyboardModel, keyboardCmd ) =
+        keyboardModel =
             Keyboard.init
     in
         ( Model keyboardModel Keyboard.NoDirection Keyboard.NoDirection
-        , Cmd.map KeyboardMsg keyboardCmd
+        , Cmd.none
         )
 
 
@@ -41,7 +41,7 @@ update msg model =
     case msg of
         KeyboardMsg keyMsg ->
             let
-                ( keyboardModel, keyboardCmd ) =
+                keyboardModel =
                     Keyboard.update keyMsg model.keyboardModel
             in
                 ( { model
@@ -49,7 +49,7 @@ update msg model =
                     , arrows = Keyboard.arrowsDirection keyboardModel
                     , wasd = Keyboard.wasdDirection keyboardModel
                   }
-                , Cmd.map KeyboardMsg keyboardCmd
+                , Cmd.none
                 )
 
 

--- a/src/Keyboard/Extra.elm
+++ b/src/Keyboard/Extra.elm
@@ -71,14 +71,14 @@ type alias Model =
 
 {-| Use this to initialize the component.
 -}
-init : ( Model, Cmd Msg )
+init : Model
 init =
-    ( Model Set.empty, Cmd.none )
+    Model Set.empty
 
 
 {-| You need to call this to have the component update.
 -}
-update : Msg -> Model -> ( Model, Cmd Msg )
+update : Msg -> Model -> Model
 update msg model =
     case msg of
         Down code ->
@@ -86,14 +86,14 @@ update msg model =
                 keysDown =
                     Set.insert code model.keysDown
             in
-                { model | keysDown = keysDown } ! []
+                { model | keysDown = keysDown }
 
         Up code ->
             let
                 keysDown =
                     Set.remove code model.keysDown
             in
-                { model | keysDown = keysDown } ! []
+                { model | keysDown = keysDown }
 
 
 {-| Gives the arrow keys' pressed down state as follows:


### PR DESCRIPTION
I was pulling this into a project of mine and saw that commands aren't used for anything.

I assume they were left there for future use, but until then, it may be a good idea to reduce that boilerplate and remove them altogether from the codebase.

Thanks for doing the hard keyboard work! Saved me a lot of time.
